### PR TITLE
docker-compose is not working on OSX

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,5 @@ docker-compose.yml
 docker-compose.*.yml
 */bin
 */obj
+*.sln
+!LiftService.sln

--- a/LiftService.Api/Dockerfile
+++ b/LiftService.Api/Dockerfile
@@ -6,29 +6,14 @@
 FROM microsoft/dotnet:2.1-aspnetcore-runtime AS base
 WORKDIR /app
 EXPOSE 80
-EXPOSE 443
 
-FROM microsoft/dotnet:2.1-sdk AS build
+FROM microsoft/dotnet:2.1-sdk AS publish
 WORKDIR /src
-
-# Copy csproj and restore as distinct layers for a Multi-stage build
-# Reference for the benefits of this:
-# https://docs.microsoft.com/en-us/dotnet/standard/microservices-architecture/docker-application-development-process/docker-app-development-workflow#multi-stage-builds-in-dockerfile
-COPY ["LiftService.Api/LiftService.Api.csproj", "LiftService.Api/"]
-COPY ["LiftService.Database/LiftService.Database.csproj", "LiftService.Database/"]
-COPY ["LiftService.Domain/LiftService.Domain.csproj", "LiftService.Domain/"]
-COPY ["LiftService.Controller/LiftService.Controller.csproj", "LiftService.Controller/"]
-RUN dotnet restore "LiftService.Api/LiftService.Api.csproj"
-
-# Copy everything else and build
 COPY . .
-WORKDIR "/src/LiftService.Api"
-RUN dotnet build "LiftService.Api.csproj" -c Release -o /app
+RUN dotnet restore /ignoreprojectextensions:.dcproj
+WORKDIR /src/LiftService.Api
+RUN dotnet publish LiftService.Api.csproj -c Release -o /app
 
-FROM build AS publish
-RUN dotnet publish "LiftService.Api.csproj" -c Release -o /app
-
-# Build runtime image
 FROM base AS final
 WORKDIR /app
 COPY --from=publish /app .

--- a/LiftService.Api/LiftService.Api.csproj
+++ b/LiftService.Api/LiftService.Api.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    <AssemblyName>LiftService.Program</AssemblyName>
-    <RootNamespace>LiftService.Program</RootNamespace>
+    <AssemblyName>LiftService.Api</AssemblyName>
+    <RootNamespace>LiftService.Api</RootNamespace>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <UserSecretsId>e6ac4515-ca3e-44c3-8183-fa8ae64b1cff</UserSecretsId>
     <DockerComposeProjectPath>..\docker-compose.dcproj</DockerComposeProjectPath>

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ To run via CLI, open the project root in a terminal. Then use the following comm
 docker-compose up
 ```
 
+Docker Compose caches your built image, so if you have previously started the service application by CLI (which you will oft do during development) you may need to use:
+
+```
+docker-compose up --build
+```
+
 Navigate to `<docker ip>:<docker port>/swagger` to interact with the API.
 
 Stop the containers with:


### PR DESCRIPTION
Issue was that I had refactored/renamed the `LiftService.Program` csproj to to be named `LiftService.Api`, but the `AssemblyName` being produced in LiftService.sln was still `LiftService.Program.dll`. 

Obviously if that is the produced file name, then running this is a useless command inside the docker container:
```
dotnet LiftService.Api.dll
```

I run this command on [L20 in the Dockerfile](https://github.com/gymt/gymt-lift-service-proto/blob/feature/13/LiftService.Api/Dockerfile#L20).

The fix was just putting the correct `AssemblyName` in LiftService.sln.

Related Issue:
https://github.com/gymt/gymt-lift-service-proto/issues/13